### PR TITLE
Enabled commenting code by shortcuts for Sublime Text.

### DIFF
--- a/Syntaxes/Comments.tmPreferences
+++ b/Syntaxes/Comments.tmPreferences
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>source.nesc</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string>// </string>
+            </dict>
+            <dict>
+                <key>name</key>
+                    <string>TM_COMMENT_START_2</string>
+                <key>value</key>
+                <string>/*</string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_END_2</string>
+                <key>value</key>
+                <string>*/</string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_DISABLE_INDENT_2</string>
+                <key>value</key>
+                <string>yes</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Needed a second file  to enable comment keyboard shortcuts in Sublime Text 2. I basically copy/pasted the following stackoverflow post:

http://stackoverflow.com/questions/18239767/enable-automatic-commenting-in-sublime-text-2-for-a-custom-syntax